### PR TITLE
Add mkdir model

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can adjust the rnn size for paragraph encoder and sentence encoder by changi
 
 ### Training:
 
-
+	mkdir model
 	th train.lua -config config-train
 
 


### PR DESCRIPTION
The training crashes if the user forgets to create the model dir first (with the standard config).